### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A powerful server implementation that enables Claude AI to interact with React applications through the Model Context Protocol.
 
+<a href="https://glama.ai/mcp/servers/xsjsdumc7x">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/xsjsdumc7x/badge" alt="https://github.com/Streen9/react-mcp MCP server" />
+</a>
+
 ## Sample Usage
 
 - [Markdown Editor/Viewer By Claude](https://claude.ai/share/f68940f1-97cd-41df-9c14-f63dc6fb9faf)
@@ -11,8 +15,6 @@ A powerful server implementation that enables Claude AI to interact with React a
 
 - [API Tester By Claude](https://claude.ai/share/b0b3943c-5c90-4b8d-8613-e76eaa243407)
   ![image](https://github.com/user-attachments/assets/dc627114-736e-4ca5-824b-cd084aa1813a)
-
-
 
 ## Overview
 


### PR DESCRIPTION
This PR adds a badge for the [https://github.com/Streen9/react-mcp](https://glama.ai/mcp/servers/xsjsdumc7x) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/xsjsdumc7x">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/xsjsdumc7x/badge" alt="https://github.com/Streen9/react-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.

## Summary by Sourcery

Documentation:
- Adds a Glama MCP server badge to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced the README with a clickable image badge for quick visual access to server information.
	- Improved overall document readability through refined formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->